### PR TITLE
Update gi-gstvideo

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@ extra-deps:
 - gi-gdkpixbuf-2.0.16
 - gi-gst-1.0.15
 - gi-gstbase-1.0.15
-- gi-gstvideo-1.0.15
+- gi-gstvideo-1.0.16
 - gi-gtk-3.0.21
 flags:
   gi-gobject:


### PR DESCRIPTION
The package gi-gstvideo-1.0.15 does not compile, but version 1.0.16 does.