### PR TITLE
fix type error with playbinBus

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -133,7 +133,7 @@ main = do
 
   turnOffSubtitles playbin
 
-  playbinBus <- GI.Gst.elementGetBus playbin
+  playbinBus <- fromJust <$> GI.Gst.elementGetBus playbin
 
   let guiObjects =
         R.GuiObjects


### PR DESCRIPTION
On line 174 it expects a Bus, but playbinBus was actually a Maybe Bus, so I put a fromJust in the definition of playbinBus.