### PR TITLE
flatpak script: quote also the 'only-arches' JSON node

### DIFF
--- a/packaging/linux/flatpak/build-module-dependencies.sh
+++ b/packaging/linux/flatpak/build-module-dependencies.sh
@@ -13,8 +13,8 @@ while read _dependency; do
   echo \
     "    {
       \"name\": \"$_dependency\",
-      "only-arches": [
-        "x86_64"
+      \"only-arches\": [
+        \"x86_64\"
       ],
       \"buildsystem\": \"simple\",
       \"build-commands\": [


### PR DESCRIPTION
Hi, I'm using your blog post as a base to publish my haskell app on flatpak and I've had an issue with the quotes. I believe it's more correct to also quote only-arches as I'm doing with this change.